### PR TITLE
Keyboard toolbar missing in SwiftUI iOS 16.1

### DIFF
--- a/IQKeyboardManager.podspec.json
+++ b/IQKeyboardManager.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "IQKeyboardManager",
-  "version": "6.5.10",
+  "version": "6.5.11",
   "source": {
     "git": "https://github.com/hackiftekhar/IQKeyboardManager.git",
-    "tag": "v6.5.10"
+    "tag": "v6.5.11"
   },
   "summary": "Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView.",
   "homepage": "https://github.com/hackiftekhar/IQKeyboardManager",

--- a/IQKeyboardManagerSwift.podspec.json
+++ b/IQKeyboardManagerSwift.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "IQKeyboardManagerSwift",
-  "version": "6.5.10",
+  "version": "6.5.11",
   "source": {
     "git": "https://github.com/hackiftekhar/IQKeyboardManager.git",
-    "tag": "v6.5.10"
+    "tag": "v6.5.11"
   },
   "summary": "Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView.",
   "homepage": "https://github.com/hackiftekhar/IQKeyboardManager",


### PR DESCRIPTION
# Description

A temporary workaround for a SwiftUI issue introduced in iOS 16.1 where initially the `inputAccessoryView` returns a private API of type `InputAccessoryHost<InputAccessoryBar>`, with a zero frame. On previous versions, `inputAccessoryView` is nil initially. This means that the guard check fails when checking for an `inputAccessoryView`, resulting in no toolbar being added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
